### PR TITLE
Add a high-level sort implementation for `ArraysEx`

### DIFF
--- a/smtlib/src/sorts.rs
+++ b/smtlib/src/sorts.rs
@@ -55,7 +55,7 @@ impl Index {
 
 pub(crate) fn is_built_in_sort(name: &str) -> bool {
     match name {
-        "Int" | "Bool" => true,
+        "Int" | "Bool" | "Array" | "BitVec" => true,
         _ => false,
     }
 }

--- a/smtlib/src/theories/arrays_ex.rs
+++ b/smtlib/src/theories/arrays_ex.rs
@@ -1,0 +1,148 @@
+#![doc = concat!("```ignore\n", include_str!("./ArraysEx.smt2"), "```")]
+
+use std::marker::PhantomData;
+
+use itertools::Itertools;
+use smtlib_lowlevel::ast::{self, Term};
+
+use crate::{
+    sorts::{Index, Sort},
+    terms::{fun, qual_ident, Const, Sorted, Dynamic, StaticSorted},
+    Bool,
+};
+
+/// Representation of a functional array with extensionality. A possibly
+/// unbounded container of values of sort Y, indexed by values of sort X.
+#[derive(Debug, Clone)]
+pub struct Array<X: Sorted, Y: Sorted>(&'static Term, PhantomData<X>, PhantomData<Y>);
+
+impl<X: Sorted, Y: Sorted> From<Const<Array<X, Y>>> for Array<X, Y> {
+    fn from(c: Const<Array<X, Y>>) -> Self {
+        c.1
+    }
+}
+
+impl<X: Sorted, Y: Sorted> std::fmt::Display for Array<X, Y> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<X: StaticSorted, Y: StaticSorted> From<Array<X, Y>> for Dynamic {
+    fn from(i: Array<X, Y>) -> Self {
+        i.into_dynamic()
+    }
+}
+
+impl<X: Sorted, Y: Sorted> From<Array<X, Y>> for Term {
+    fn from(i: Array<X, Y>) -> Self {
+        i.0.clone()
+    }
+}
+impl<X: Sorted, Y: Sorted> From<Term> for Array<X, Y> {
+    fn from(t: Term) -> Self {
+        Array(Box::leak(Box::new(t)), PhantomData, PhantomData)
+    }
+}
+
+impl<X: StaticSorted, Y: StaticSorted> StaticSorted for Array<X, Y> {
+    type Inner = Self;
+    fn static_sort() -> Sort {
+        Sort::new_parametric("Array", vec![X::static_sort(), Y::static_sort()])
+    }
+}
+
+#[allow(unused)]
+impl<X: StaticSorted, Y: StaticSorted> Array<X, Y> {
+    /// The value stored at `index` --- `(select self index)`
+    fn select(&self, index: X) -> Y {
+        fun("select", vec![self.0.clone(), index.into()]).into()
+    }
+    /// Copy of this array with `value` stored at `index` --- `(store self index value)`
+    fn store(&self, index: X, value: Y) -> Array<X, Y> {
+        fun("store", vec![self.0.clone(), index.into(), value.into()]).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use smtlib_lowlevel::backend::z3_binary::Z3Binary;
+
+    use crate::{terms::{Sorted, StaticSorted}, Int, Solver};
+
+    use super::Array;
+
+    #[test]
+    fn define_array() -> Result<(), Box<dyn std::error::Error>> {
+
+        let mut solver = Solver::new(Z3Binary::new("z3")?)?;
+        let a = Array::<Int, Int>::new_const("a");
+
+        solver.assert(a.clone()._eq(a.clone()))?;
+
+        let _model = solver.check_sat_with_model()?.expect_sat()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn read_stored() -> Result<(), Box<dyn std::error::Error>> {
+
+        let mut solver = Solver::new(Z3Binary::new("z3")?)?;
+        let a = Array::<Int, Int>::new_const("a");
+        let x = Int::new_const("x");
+        let y = Int::new_const("y");
+
+        let updated = a.store(x.into(), y.into());
+        let read = updated.select(x.into());
+
+        solver.assert(read._eq(y))?;
+
+        let _model = solver.check_sat_with_model()?.expect_sat()?;
+
+        Ok(())
+    }
+
+
+    #[test]
+    fn read_stored_incorrect() -> Result<(), Box<dyn std::error::Error>> {
+
+        let mut solver = Solver::new(Z3Binary::new("z3")?)?;
+        let a = Array::<Int, Int>::new_const("a");
+        let x = Int::new_const("x");
+        let y = Int::new_const("y");
+
+        let updated = a.store(x.into(), y.into());
+        let read = updated.select(x.into());
+
+        solver.assert(read._neq(y))?;
+
+        let res = solver.check_sat()?;
+
+        match res {
+            crate::SatResult::Unsat => Ok(()),
+            s => Err(Box::new(crate::Error::UnexpectedSatResult { expected: crate::SatResult::Unsat, actual: s })),
+        }
+    }
+
+    #[test]
+    fn read_untouched() -> Result<(), Box<dyn std::error::Error>> {
+
+        let mut solver = Solver::new(Z3Binary::new("z3")?)?;
+        let a = Array::<Int, Int>::new_const("a");
+        let x = Int::new_const("x");
+        let y = Int::new_const("y");
+        let z = Int::new_const("z");
+
+        let updated = a.store(x.into(), y.into());
+        let read = updated.select(z.into());
+        
+        solver.assert(x._neq(z))?;
+        solver.assert(read._neq(y))?;
+
+        let _model = solver.check_sat_with_model()?.expect_sat()?;
+
+        Ok(())
+    }
+
+}

--- a/smtlib/src/theories/arrays_ex.rs
+++ b/smtlib/src/theories/arrays_ex.rs
@@ -6,7 +6,7 @@ use smtlib_lowlevel::ast::Term;
 
 use crate::{
     sorts::Sort,
-    terms::{fun, Const, Sorted, Dynamic, StaticSorted},
+    terms::{fun, Const, Dynamic, Sorted, StaticSorted},
 };
 
 /// Representation of a functional array with extensionality. A possibly
@@ -66,14 +66,16 @@ impl<X: StaticSorted, Y: StaticSorted> Array<X, Y> {
 mod tests {
     use smtlib_lowlevel::backend::z3_binary::Z3Binary;
 
-    use crate::{terms::{Sorted, StaticSorted}, Int, Solver};
+    use crate::{
+        terms::{Sorted, StaticSorted},
+        Int, Solver,
+    };
 
     use super::Array;
 
     /// Check that an array can be defined using the high-level API
     #[test]
     fn define_array() -> Result<(), Box<dyn std::error::Error>> {
-
         let mut solver = Solver::new(Z3Binary::new("z3")?)?;
         let a = Array::<Int, Int>::new_const("a");
 
@@ -87,7 +89,6 @@ mod tests {
     /// Check that a value stored at an index can be correctly retrieved
     #[test]
     fn read_stored() -> Result<(), Box<dyn std::error::Error>> {
-
         let mut solver = Solver::new(Z3Binary::new("z3")?)?;
         let a = Array::<Int, Int>::new_const("a");
         let x = Int::new_const("x");
@@ -103,11 +104,9 @@ mod tests {
         Ok(())
     }
 
-
     /// Check that a value stored at an index is guaranteed to be retrieved
     #[test]
     fn read_stored_incorrect() -> Result<(), Box<dyn std::error::Error>> {
-
         let mut solver = Solver::new(Z3Binary::new("z3")?)?;
         let a = Array::<Int, Int>::new_const("a");
         let x = Int::new_const("x");
@@ -122,14 +121,16 @@ mod tests {
 
         match res {
             crate::SatResult::Unsat => Ok(()),
-            s => Err(Box::new(crate::Error::UnexpectedSatResult { expected: crate::SatResult::Unsat, actual: s })),
+            s => Err(Box::new(crate::Error::UnexpectedSatResult {
+                expected: crate::SatResult::Unsat,
+                actual: s,
+            })),
         }
     }
 
     /// Check that a store does not affect values other than the target index
     #[test]
     fn read_untouched() -> Result<(), Box<dyn std::error::Error>> {
-
         let mut solver = Solver::new(Z3Binary::new("z3")?)?;
         let a = Array::<Int, Int>::new_const("a");
         let x = Int::new_const("x");
@@ -138,7 +139,7 @@ mod tests {
 
         let updated = a.store(x.into(), y.into());
         let read = updated.select(z.into());
-        
+
         solver.assert(x._neq(z))?;
         solver.assert(read._neq(y))?;
 
@@ -146,5 +147,4 @@ mod tests {
 
         Ok(())
     }
-
 }

--- a/smtlib/src/theories/arrays_ex.rs
+++ b/smtlib/src/theories/arrays_ex.rs
@@ -2,13 +2,11 @@
 
 use std::marker::PhantomData;
 
-use itertools::Itertools;
-use smtlib_lowlevel::ast::{self, Term};
+use smtlib_lowlevel::ast::Term;
 
 use crate::{
-    sorts::{Index, Sort},
-    terms::{fun, qual_ident, Const, Sorted, Dynamic, StaticSorted},
-    Bool,
+    sorts::Sort,
+    terms::{fun, Const, Sorted, Dynamic, StaticSorted},
 };
 
 /// Representation of a functional array with extensionality. A possibly

--- a/smtlib/src/theories/arrays_ex.rs
+++ b/smtlib/src/theories/arrays_ex.rs
@@ -70,6 +70,7 @@ mod tests {
 
     use super::Array;
 
+    /// Check that an array can be defined using the high-level API
     #[test]
     fn define_array() -> Result<(), Box<dyn std::error::Error>> {
 
@@ -83,6 +84,7 @@ mod tests {
         Ok(())
     }
 
+    /// Check that a value stored at an index can be correctly retrieved
     #[test]
     fn read_stored() -> Result<(), Box<dyn std::error::Error>> {
 
@@ -102,6 +104,7 @@ mod tests {
     }
 
 
+    /// Check that a value stored at an index is guaranteed to be retrieved
     #[test]
     fn read_stored_incorrect() -> Result<(), Box<dyn std::error::Error>> {
 
@@ -123,6 +126,7 @@ mod tests {
         }
     }
 
+    /// Check that a store does not affect values other than the target index
     #[test]
     fn read_untouched() -> Result<(), Box<dyn std::error::Error>> {
 

--- a/smtlib/src/theories/ints.rs
+++ b/smtlib/src/theories/ints.rs
@@ -5,7 +5,7 @@ use smtlib_lowlevel::{ast::Term, lexicon::Numeral};
 use crate::{
     impl_op,
     sorts::Sort,
-    terms::{fun, qual_ident, Const, Dynamic, Sorted, StaticSorted},
+    terms::{fun, Const, Dynamic, Sorted, StaticSorted},
     Bool,
 };
 

--- a/smtlib/src/theories/mod.rs
+++ b/smtlib/src/theories/mod.rs
@@ -1,6 +1,7 @@
 //! Theories in SMT-LIB are definitions of [sorts](crate::Sort) and in general
 //! functions present in the [logics](crate::Logic).
 
+pub mod arrays_ex;
 pub mod core;
 pub mod fixed_size_bit_vectors;
 pub mod ints;


### PR DESCRIPTION
As title says.

Follows the `BitVec` implementation in style and the required implementations. The difference, as expected, is that the constant to and fro conversions are not applicable here.

Some basic tests are added to check that the high-level API correctly maps the SMT-LIB semantics.

I'm no Rust expert, so please feel free to critique extensively.

The only two functions on an array are `select` and `sort`. The notation `a.select(x)` is used for `(select a x)`, and similarly `a.store(x, y)` for `(store a x y)`.

There is one minor extraneous change to `ints.rs` arising from `cargo fix`