### PR TITLE
Solver: add check_sat_assuming

### DIFF
--- a/smtlib/src/solver.rs
+++ b/smtlib/src/solver.rs
@@ -9,7 +9,7 @@ use smtlib_lowlevel::{
 
 use crate::{
     funs, sorts,
-    terms::{qual_ident, Dynamic},
+    terms::{qual_ident, Const, Dynamic},
     Bool, Error, Logic, Model, SatResult, SatResultWithModel, Sorted,
 };
 
@@ -156,6 +156,38 @@ where
             SatResult::Unsat => Ok(SatResultWithModel::Unsat),
             SatResult::Sat => Ok(SatResultWithModel::Sat(self.get_model()?)),
             SatResult::Unknown => Ok(SatResultWithModel::Unknown),
+        }
+    }
+
+    /// Checks for satisfiability of the assertions sent to the solver using
+    /// [`Solver::assert`] as well as the ones provided in the assumptions.
+    /// A satisfying model can be fetched using [`Solver::get_model`] in case
+    /// of `sat`.
+    ///
+    /// `check_sat_assuming` preserves the context and the given assumptions do
+    /// not affect later calls to [`Solver::check_sat`].
+    pub fn check_sat_assuming(
+        &mut self,
+        assumptions: &[Const<'st, Bool<'st>>],
+    ) -> Result<SatResult, Error> {
+        let mut prop_lits = Vec::new();
+        for assumption in assumptions {
+            self.declare_all_consts(assumption.term())?;
+            let name = self.st().alloc_str(assumption.name());
+            prop_lits.push(ast::PropLiteral::Symbol(Symbol(name)));
+        }
+        let prop_lits = self.st().alloc_slice(&prop_lits);
+        let cmd = ast::Command::CheckSatAssuming(prop_lits);
+        match self.driver.exec(cmd)? {
+            ast::GeneralResponse::SpecificSuccessResponse(
+                ast::SpecificSuccessResponse::CheckSatResponse(res),
+            ) => Ok(match res {
+                ast::CheckSatResponse::Sat => SatResult::Sat,
+                ast::CheckSatResponse::Unsat => SatResult::Unsat,
+                ast::CheckSatResponse::Unknown => SatResult::Unknown,
+            }),
+            ast::GeneralResponse::Error(msg) => Err(Error::Smt(msg.to_string(), format!("{cmd}"))),
+            res => todo!("{res:?}"),
         }
     }
     /// Produces the model for satisfying the assertions. If you are looking to

--- a/smtlib/src/tests.rs
+++ b/smtlib/src/tests.rs
@@ -38,3 +38,24 @@ fn negative_numbers() {
         None => panic!("Oh no! This should never happen, as x was part of an assert"),
     }
 }
+
+#[test]
+fn check_sat_assuming() {
+    let st = Storage::new();
+    let mut solver =
+        Solver::new(&st, crate::backend::z3_binary::Z3Binary::new("z3").unwrap()).unwrap();
+
+    let x = Int::new_const(&st, "x");
+    let prop_1 = Bool::new_const(&st, "prop_1");
+    let prop_2 = Bool::new_const(&st, "prop_2");
+    solver.assert(prop_1.implies(x._eq(42))).unwrap();
+    solver.assert(prop_2.implies(x._neq(42))).unwrap();
+    solver.assert(*prop_1).unwrap();
+
+    assert_eq!(solver.check_sat().unwrap(), SatResult::Sat);
+    assert_eq!(
+        solver.check_sat_assuming(&[prop_2]).unwrap(),
+        SatResult::Unsat
+    );
+    assert_eq!(solver.check_sat().unwrap(), SatResult::Sat);
+}


### PR DESCRIPTION
Hi,
this implements support for `check-sat-assuming`. I've used `Storage::alloc_{str,slice}` for the assumption slice which is probably fine, but there might be a nicer way to do this?
Note that this doesn't expose lowlevel's `PropLiteral` type, so we don't support negated `Const<Bool>`s here. Since solvers do support negated props for assumptions, it might be useful to add a new PropLiteral-like type in the high-level API or just consume two slices where one represents negated assumptions?