### PR TITLE
Add ability to construct reals with 'new' like ints

### DIFF
--- a/smtlib/src/theories/reals.rs
+++ b/smtlib/src/theories/reals.rs
@@ -73,6 +73,11 @@ impl<'st> IntoWithStorage<'st, Real<'st>> for f64 {
     }
 }
 impl<'st> Real<'st> {
+    /// Construct a new real.
+    pub fn new(st: &'st Storage, value: impl IntoWithStorage<'st, Real<'st>>) -> Real<'st> {
+        value.into_with_storage(st)
+    }
+
     /// Returns the sort of reals.
     pub fn sort() -> Sort<'st> {
         Self::AST_SORT.into()


### PR DESCRIPTION
Reals seem to lack the "new" function the same way integers so this pr adds that.