### PR TITLE
Fix stack overflow with cargo xtask ast

### DIFF
--- a/xtask/src/ast.rs
+++ b/xtask/src/ast.rs
@@ -116,7 +116,7 @@ impl Name {
                 }),
                 Some(Syntax::Class { response: _, cases }) => cases.iter().any(|(_, case)| {
                     case.syntax.fields.iter().any(|f| match f {
-                        Field::One(name) => name.needs_lt(spec),
+                        Field::One(name) => name == self || name.needs_lt(spec),
                         Field::Any(_) | Field::NonZero(_) | Field::NPlusOne(_) => true,
                     })
                 }),


### PR DESCRIPTION
I ran into the following issue:

```
$ cargo xtask ast

thread 'main' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

this seems to be cause by [this commit](https://github.com/oeb25/smtlib-rs/commit/85ded7de77f9adf6c90b54db05248bc1a65a5c84), which updated the dependency that is leading to things being handled in a different order. I prevented the infinite loop and regenerated `ast.rs`, which should be unchanged except for the order of everything.